### PR TITLE
add router path children, createElement to set defaultProps

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /npm-debug.log
 /node_modules
 .DS_Store
+.idea

--- a/lib/entry.nunjucks.js
+++ b/lib/entry.nunjucks.js
@@ -14,15 +14,20 @@ const templateWrapper = require('./utils/template-wrapper.nunjucks');
 const theme = require('{{ themePath }}');
 theme.completedRoutes = toCompletedRoutes(theme.routes);
 
-const routes = theme.completedRoutes.map(
-  (item, index) =>
-    React.createElement(Route, {
-      key: `route-${index}`,
-      path: item.route,
-      onEnter: () => NProgress.start(),
-      getComponents: templateWrapper(item.template, item.dataPath),
-    })
-);
+const getChildenRoutes = (item, index) => {
+  const children = (item.children || []).map(getChildenRoutes);
+  const path = item.route || item.dataPath;
+  const props = Object.assign({}, item.props);
+  return React.createElement(Route, Object.assign({}, props, {
+    key: `route-${index}`,
+    path: path,
+    onEnter: () => NProgress.start(),
+    getComponents: templateWrapper(item.template, item.dataPath),
+    children: children,
+  }));
+};
+const routes = theme.completedRoutes.map(getChildenRoutes);
+
 routes.push(React.createElement(Route, {
   key: 'not-found',
   path: '*',

--- a/lib/utils/template-wrapper.nunjucks.js
+++ b/lib/utils/template-wrapper.nunjucks.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const React = require('react');
+
 const chain = require('ramda/src/chain');
 const toReactComponent = require('jsonml-to-react-component');
 const exist = require('exist.js');
@@ -46,14 +46,15 @@ module.exports = function templateWrapper(template, dataPath = '') {
       pageData,
       utils,
     }), (err, nextProps) => {
-      callback(err, (props) => {
-        NProgress.done();
-        return React.createElement(
-          !hasParams(dataPath) || pageData ?
-            Template.default || Template : NotFound,
-          Object.assign({}, props, nextProps)
-        );
+      NProgress.done();
+      const Comp = !hasParams(dataPath) || pageData ?
+      Template.default || Template : NotFound;
+      Comp.defaultProps = Object.assign({}, Comp.defaultProps, nextProps, {
+        data: data.markdown,
+        pageData,
+        utils,
       });
+      callback(err, Comp);
     });
   };
 };


### PR DESCRIPTION
增加子级路由
```jsx
routes: [
    {
      template: './template/Layout/index',
      props: { ignoreScrollBehavior: true },
      children : [
        { dataPath: '/', template: './template/Home/index' },
        { dataPath: '/components/:contentName', template: ComponentDoc },
      ]
    }
  ]
```