### PR TITLE
Kill subcommand proccess when main proccess is exiting.

### DIFF
--- a/bin/bisheng
+++ b/bin/bisheng
@@ -10,3 +10,7 @@ program
   .command('build [options]', 'to build and write static files to `config.output`')
   .command('gh-pages [options]', 'to deploy website to gh-pages')
   .parse(process.argv);
+
+process.on('exit', function() {
+  program.runningCommand && program.runningCommand.kill();
+});


### PR DESCRIPTION
Fix #43 

😐 挖了半天最后发现是 commander 的问题，commander 会给子命令开一个新进程。但是主命令的进程退出的时候如果子进程（也就是 bisheng-start）正在 build 中的话，就要等 build 完成才会退出，所以端口会被继续暂用。