### PR TITLE
Kill subcommand proccess when main proccess is exiting.

### DIFF
--- a/bin/bisheng
+++ b/bin/bisheng
@@ -10,3 +10,8 @@ program
   .command('build [options]', 'to build and write static files to `config.output`')
   .command('gh-pages [options]', 'to deploy website to gh-pages')
   .parse(process.argv);
+
+process.on('SIGINT', function() {
+  program.runningCommand && program.runningCommand.kill('SIGKILL');
+  process.exit(0);
+});


### PR DESCRIPTION
换了比较暴力的 SIGKILL 应该可以了，在主命令退出的时候立即杀掉子进程。