### PR TITLE
Exit 130 when receive SIGINT

### DIFF
--- a/packages/bisheng/bin/bisheng
+++ b/packages/bisheng/bin/bisheng
@@ -13,5 +13,5 @@ program
 
 process.on('SIGINT', function() {
   program.runningCommand && program.runningCommand.kill('SIGKILL');
-  process.exit(0);
+  process.exit(130);
 });


### PR DESCRIPTION
> "deploy": "antd-tools run clean && npm run site && bisheng gh-pages --push-only",

`npm run site` exit 0 的话会导致 `bisheng gh-pages --push-only` 继续运行。

cc @afc163 