### PR TITLE
增加HashHistory模式选项配置

### DIFF
--- a/packages/bisheng/src/entry.nunjucks.jsx
+++ b/packages/bisheng/src/entry.nunjucks.jsx
@@ -7,6 +7,7 @@ const React = require('react');
 const ReactDOM = require('react-dom');
 const ReactRouter = require('react-router');
 const history = require('history');
+const createHashHistory = require('history/lib/createHashHistory');
 const data = require('../lib/utils/data.js');
 const createElement = require('../lib/utils/create-element');
 const routes = require('{{ routesPath }}')(data);
@@ -14,10 +15,14 @@ const routes = require('{{ routesPath }}')(data);
 const { pathname, search, hash } = window.location;
 const location = `${pathname}${search}${hash}`;
 const basename = '{{ root }}';
+const historyMode = '{{history}}';
 ReactRouter.match({ routes, location, basename }, () => {
+  const createHistory = historyMode === 'browser'
+    ? history.createHistory
+    : (createHashHistory.default || createHashHistory);
   const router = (
     <ReactRouter.Router
-      history={ReactRouter.useRouterHistory(history.createHistory)({ basename })}
+      history={ReactRouter.useRouterHistory(createHistory)({ basename })}
       routes={routes}
       createElement={createElement}
     />

--- a/packages/bisheng/src/index.js
+++ b/packages/bisheng/src/index.js
@@ -40,7 +40,7 @@ function getRoutesPath(configPath, themePath, configEntryName) {
   return routesPath;
 }
 
-function generateEntryFile(configPath, configTheme, configEntryName, root) {
+function generateEntryFile(configPath, configTheme, configEntryName, root, history) {
   const entryPath = path.join(tmpDirPath, `entry.${configEntryName}.js`);
   const routesPath = getRoutesPath(
     configPath,
@@ -52,6 +52,7 @@ function generateEntryFile(configPath, configTheme, configEntryName, root) {
     nunjucks.renderString(entryTemplate, {
       routesPath: escapeWinPath(routesPath),
       root: escapeWinPath(root),
+      history,
     }),
   );
 }
@@ -72,6 +73,7 @@ exports.start = function start(program) {
     bishengConfig.theme,
     bishengConfig.entryName,
     '/',
+    bishengConfig.history,
   );
 
   const webpackConfig = updateWebpackConfig(getWebpackCommonConfig(), 'start');
@@ -130,6 +132,7 @@ exports.build = function build(program, callback) {
     bishengConfig.theme,
     entryName,
     bishengConfig.root,
+    bishengConfig.history,
   );
   const webpackConfig = updateWebpackConfig(getWebpackCommonConfig(), 'build');
   webpackConfig.plugins.push(new webpack.LoaderOptionsPlugin({

--- a/packages/bisheng/src/utils/get-bisheng-config.js
+++ b/packages/bisheng/src/utils/get-bisheng-config.js
@@ -28,6 +28,7 @@ const defaultConfig = {
 
   entryName: 'index',
   root: '/',
+  history: 'browser',
   filePathMapper(filePath) {
     return filePath;
   },


### PR DESCRIPTION
目前ali site还仅支持hashHistory mode，因此希望增加一个bisheng config配置项可以配置是使用browserHistory还是hashHistory。
```js
{
    history: 'hash',  // 默认为browser
    port: 8435,
    ....
}
```