### PR TITLE
refactor(bisheng): move `getThemeConfig` call to index.js

### DIFF
--- a/packages/bisheng/src/index.js
+++ b/packages/bisheng/src/index.js
@@ -15,6 +15,7 @@ const ghPages = require('gh-pages');
 const getBishengConfig = require('./utils/get-bisheng-config');
 const sourceData = require('./utils/source-data');
 const generateFilesPath = require('./utils/generate-files-path');
+const getThemeConfig = require('./utils/get-theme-config');
 const context = require('./context');
 
 const entryTemplate = fs.readFileSync(path.join(__dirname, 'entry.nunjucks.js')).toString();
@@ -22,44 +23,14 @@ const routesTemplate = fs.readFileSync(path.join(__dirname, 'routes.nunjucks.js'
 const tmpDirPath = path.join(__dirname, '..', 'tmp');
 mkdirp.sync(tmpDirPath);
 
-function getDefaultOfModule(module) {
-  return module.default || module;
-}
-
-function getRoutesPath(configPath, themePath, configEntryName) {
-  const routesPath = path.join(tmpDirPath, `routes.${configEntryName}.js`);
-  const themeConfig = require(escapeWinPath(configPath)).themeConfig || {};
-  fs.writeFileSync(
-    routesPath,
-    nunjucks.renderString(routesTemplate, {
-      themePath: escapeWinPath(themePath),
-      themeConfig: JSON.stringify(themeConfig),
-      themeRoutes: JSON.stringify(getDefaultOfModule(require(themePath)).routes),
-    }),
-  );
-  return routesPath;
-}
-
-function generateEntryFile(configPath, configTheme, configEntryName, root) {
-  const entryPath = path.join(tmpDirPath, `entry.${configEntryName}.js`);
-  const routesPath = getRoutesPath(
-    configPath,
-    path.dirname(configTheme),
-    configEntryName,
-  );
-  fs.writeFileSync(
-    entryPath,
-    nunjucks.renderString(entryTemplate, {
-      routesPath: escapeWinPath(routesPath),
-      root: escapeWinPath(root),
-    }),
-  );
-}
-
 exports.start = function start(program) {
   const configFile = path.join(process.cwd(), program.config || 'bisheng.config.js');
   const bishengConfig = getBishengConfig(configFile);
-  context.initialize({ bishengConfig });
+  const themeConfig = getThemeConfig(bishengConfig.theme);
+  context.initialize({
+    bishengConfig,
+    themeConfig,
+  });
   mkdirp.sync(bishengConfig.output);
 
   const template = fs.readFileSync(bishengConfig.htmlTemplate).toString();
@@ -68,7 +39,6 @@ exports.start = function start(program) {
   fs.writeFileSync(templatePath, nunjucks.renderString(template, templateData));
 
   generateEntryFile(
-    configFile,
     bishengConfig.theme,
     bishengConfig.entryName,
     '/',
@@ -115,18 +85,20 @@ function filenameToUrl(filename) {
   }
   return filename.replace(/\.html$/, '');
 }
+
 exports.build = function build(program, callback) {
   const configFile = path.join(process.cwd(), program.config || 'bisheng.config.js');
   const bishengConfig = getBishengConfig(configFile);
+  const themeConfig = getThemeConfig(bishengConfig.theme);
   context.initialize({
     bishengConfig,
+    themeConfig,
     isBuild: true,
   });
   mkdirp.sync(bishengConfig.output);
 
   const { entryName } = bishengConfig;
   generateEntryFile(
-    configFile,
     bishengConfig.theme,
     entryName,
     bishengConfig.root,
@@ -149,7 +121,7 @@ exports.build = function build(program, callback) {
 
   const ssrWebpackConfig = Object.assign({}, webpackConfig);
   const ssrPath = path.join(tmpDirPath, `ssr.${entryName}.js`);
-  const routesPath = getRoutesPath(configFile, path.dirname(bishengConfig.theme), entryName);
+  const routesPath = getRoutesPath(path.dirname(bishengConfig.theme), entryName);
   fs.writeFileSync(ssrPath, nunjucks.renderString(ssrTemplate, { routesPath: escapeWinPath(routesPath) }));
 
   ssrWebpackConfig.entry = {
@@ -175,7 +147,6 @@ exports.build = function build(program, callback) {
     }
 
     const markdown = sourceData.generate(bishengConfig.source, bishengConfig.transformers);
-    const themeConfig = require(bishengConfig.theme);
     let filesNeedCreated = generateFilesPath(themeConfig.routes, markdown).map(bishengConfig.filePathMapper);
     filesNeedCreated = R.unnest(filesNeedCreated);
 
@@ -270,3 +241,36 @@ exports.deploy = function deploy(program) {
     exports.build(program, () => pushToGhPages(basePath, config));
   }
 };
+
+function getDefaultOfModule(module) {
+  return module.default || module;
+}
+
+function getRoutesPath(themePath, configEntryName) {
+  const routesPath = path.join(tmpDirPath, `routes.${configEntryName}.js`);
+  const { bishengConfig, themeConfig } = context;
+  fs.writeFileSync(
+    routesPath,
+    nunjucks.renderString(routesTemplate, {
+      themePath: escapeWinPath(themePath),
+      themeConfig: JSON.stringify(bishengConfig.themeConfig),
+      themeRoutes: JSON.stringify(themeConfig.routes),
+    }),
+  );
+  return routesPath;
+}
+
+function generateEntryFile(configTheme, configEntryName, root) {
+  const entryPath = path.join(tmpDirPath, `entry.${configEntryName}.js`);
+  const routesPath = getRoutesPath(
+    path.dirname(configTheme),
+    configEntryName,
+  );
+  fs.writeFileSync(
+    entryPath,
+    nunjucks.renderString(entryTemplate, {
+      routesPath: escapeWinPath(routesPath),
+      root: escapeWinPath(root),
+    }),
+  );
+}

--- a/packages/bisheng/src/loaders/bisheng-data-loader.js
+++ b/packages/bisheng/src/loaders/bisheng-data-loader.js
@@ -1,6 +1,5 @@
 const fs = require('fs');
 const path = require('path');
-const getThemeConfig = require('../utils/get-theme-config');
 const sourceData = require('../utils/source-data');
 const resolvePlugins = require('../utils/resolve-plugins');
 const context = require('../context');
@@ -11,8 +10,7 @@ module.exports = function bishengDataLoader(/* content */) {
     this.cacheable();
   }
 
-  const { bishengConfig } = context;
-  const themeConfig = getThemeConfig(bishengConfig.theme);
+  const { bishengConfig, themeConfig } = context;
 
   const markdown = sourceData.generate(bishengConfig.source, bishengConfig.transformers);
   const browserPlugins = resolvePlugins(themeConfig.plugins, 'browser');

--- a/packages/bisheng/src/loaders/source-loader.js
+++ b/packages/bisheng/src/loaders/source-loader.js
@@ -1,6 +1,5 @@
 const path = require('path');
 const loaderUtils = require('loader-utils');
-const getThemeConfig = require('../utils/get-theme-config');
 const resolvePlugins = require('../utils/resolve-plugins');
 const context = require('../context');
 const boss = require('./common/boss');
@@ -13,8 +12,7 @@ module.exports = function sourceLoader(content) {
   const fullPath = webpackRemainingChain[webpackRemainingChain.length - 1];
   const filename = path.relative(process.cwd(), fullPath);
 
-  const { bishengConfig } = context;
-  const themeConfig = getThemeConfig(bishengConfig.theme);
+  const { bishengConfig, themeConfig } = context;
   const plugins = resolvePlugins(themeConfig.plugins, 'node');
 
   const callback = this.async();


### PR DESCRIPTION
目前 `getThemeConfig` 函数的调用位于两个 loader 的实现之中：

- packages/bisheng/src/loaders/bisheng-data-loader.js
- packages/bisheng/src/loaders/source-loader.js

由于 getThemeConfig 内部添加了 `bisheng-plugin-highlight`，导致这部分逻辑和 bisheng (react) 过度耦合了，不利于 bisheng-core 拆分。

此修改将 `getThemeConfig` 的调用放到了 index.js 中，注入到 context。木的事实现这部分的解耦。在职责划分上，计划 context 用于存放 bisheng-core 需要的数据，context的数据由 bisheng 来注入，从而支持一些定制化（plugin默认值等）的需求。

顺便移除了 index.js 中一些多余的 require。