### PR TITLE
修复推送到其它远程仓库: gh-pages 官方选项是repo 不是 remote

### DIFF
--- a/packages/bisheng/src/index.js
+++ b/packages/bisheng/src/index.js
@@ -288,7 +288,7 @@ function pushToGhPages(basePath, config) {
 }
 exports.deploy = function deploy(program) {
   const config = {
-    remote: program.remote,
+    repo: program.remote,
     branch: program.branch,
   };
   if (program.pushOnly) {


### PR DESCRIPTION
修复推送到其它远程仓库: gh-pages 官方选项是repo 不是 remote

https://github.com/tschaub/gh-pages

![image](https://user-images.githubusercontent.com/9738969/51458116-fdac4d80-1d8e-11e9-88ec-204975ae39c0.png)
