### PR TITLE
feat: css hash, fix: auto hash entrypoint

### DIFF
--- a/packages/bisheng/src/config/getWebpackCommonConfig.js
+++ b/packages/bisheng/src/config/getWebpackCommonConfig.js
@@ -14,11 +14,15 @@ import CleanUpStatsPlugin from '../utils/CleanUpStatsPlugin';
 /* eslint quotes:0 */
 
 export default function getWebpackCommonConfig() {
+  const { isBuild, bishengConfig } = context;
   const NODE_ENV = process.env.NODE_ENV || 'production';
   const isProd = NODE_ENV === 'production';
   const fileNameHash = `[name]${isProd ? '.[contenthash:6]' : ''}`;
   const chunkFileName = `${fileNameHash}.js`;
-  const cssFileName = '[name].css';
+  const isHash = isBuild && bishengConfig.hash;
+  const cssFileName = isHash
+    ? '[name]-[contenthash:8].css'
+    : '[name].css';
 
   const babelOptions = getBabelCommonConfig();
   const tsOptions = getTSCommonConfig();

--- a/packages/bisheng/src/index.js
+++ b/packages/bisheng/src/index.js
@@ -145,6 +145,8 @@ function filenameToUrl(filename) {
   return filename.replace(/\.html$/, '');
 }
 
+// hash { js: ['index-{hash}.js', ...], css: [ 'index.{hash}-{chunkId}.css' ] }
+// no hash // { js: ['index.js', ...], css: [ 'index.{chunkId}.css' ] }
 function getManifest(compilation) {
   const manifest = {}
   compilation.entrypoints.forEach((entrypoint, name) => {

--- a/packages/bisheng/src/template.html
+++ b/packages/bisheng/src/template.html
@@ -4,7 +4,8 @@
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <link rel="stylesheet" type="text/css" href="{{ root }}index.css"/>
+    {% for cssFile in manifest["css"] %}<link rel="stylesheet" type="text/css" href="{{ root }}{{ cssFile }}"/>
+    {% endfor %}
     <!--[if lt IE 10]>
       <script src="https://as.alipayobjects.com/g/component/??console-polyfill/0.2.2/index.js,es5-shim/4.5.7/es5-shim.min.js,es5-shim/4.5.7/es5-sham.min.js,html5shiv/3.7.2/html5shiv.min.js,media-match/2.0.2/media.match.min.js"></script>
     <![endif]-->
@@ -13,9 +14,6 @@
     <div id="react-content">{{ content | safe }}</div>
   </body>
   <script src="{{ root }}common.js"></script>
-  {% if hash %}
-  <script src="{{ root }}{{ manifest['index.js'] }}"></script>
-  {% else %}
-  <script src="{{ root }}index.js"></script>
-  {% endif %}
+  {% for jsFile in manifest["js"] %}<script src="{{ root }}{{ jsFile }}"></script>
+  {% endfor %}
 </html>


### PR DESCRIPTION
## Usage

```js
// bisheng.config.js

module.exports = {
	...
	hash: true,
	...
}
```


```html
// user-defined template template.html
<head>
 {% for cssFile in manifest["css"] %}<link rel="stylesheet" type="text/css" href="{{ root }}{{ cssFile }}"/>
 {% endfor %}
</head>

<body>
...
   {% for jsFile in manifest["js"] %}<script src="{{ root }}{{ jsFile }}"></script>
   {% endfor %}
...
</body>
```