### PR TITLE
Fix autoprefixer warning and add skip ci

### DIFF
--- a/packages/bisheng/package.json
+++ b/packages/bisheng/package.json
@@ -77,7 +77,7 @@
     "css-loader": "~2.1.0",
     "exist.js": "^0.3.0",
     "friendly-errors-webpack-plugin": "^1.6.1",
-    "gh-pages": "^1.0.0",
+    "gh-pages": "^2.1.1",
     "history": "^3.3.0",
     "jsonml-to-react-element": "^1.0.0",
     "jsonml.js": "^0.1.0",

--- a/packages/bisheng/src/index.js
+++ b/packages/bisheng/src/index.js
@@ -329,9 +329,11 @@ exports.build = function build(program, callback) {
 };
 
 function pushToGhPages(basePath, config) {
+  const now = new Date();
   const options = {
     ...config,
     depth: 1,
+    message: `Deploy to gh-pages - ${now.getHours()}:${now.getMinutes()}:${now.getSeconds()} [ci skip]`,
     logger(message) {
       console.log(message);
     },

--- a/packages/bisheng/src/index.js
+++ b/packages/bisheng/src/index.js
@@ -342,6 +342,7 @@ function pushToGhPages(basePath, config) {
       email: process.env.RUN_ENV_EMAIL,
     };
   }
+  console.log(options);
   ghPages.publish(basePath, options, (err) => {
     if (err) {
       throw err;

--- a/packages/bisheng/src/index.js
+++ b/packages/bisheng/src/index.js
@@ -342,7 +342,6 @@ function pushToGhPages(basePath, config) {
       email: process.env.RUN_ENV_EMAIL,
     };
   }
-  console.log(options);
   ghPages.publish(basePath, options, (err) => {
     if (err) {
       throw err;

--- a/packages/bisheng/src/index.js
+++ b/packages/bisheng/src/index.js
@@ -346,7 +346,7 @@ function pushToGhPages(basePath, config) {
     if (err) {
       throw err;
     }
-    console.log('Site has been published!');
+    console.log('✅ Site has been published!');
   });
 }
 exports.deploy = function deploy(program) {

--- a/packages/bisheng/src/utils/get-bisheng-config.js
+++ b/packages/bisheng/src/utils/get-bisheng-config.js
@@ -17,9 +17,7 @@ const defaultConfig = {
   postcssConfig: {
     plugins: [
       rucksack(),
-      autoprefixer({
-        browsers: ['last 2 versions', 'Firefox ESR', '> 1%', 'ie >= 8', 'iOS >= 8', 'Android >= 4'],
-      }),
+      autoprefixer(),
     ],
   },
   webpackConfig(config) {

--- a/packages/bisheng/test/fixtures/bisheng.config.js
+++ b/packages/bisheng/test/fixtures/bisheng.config.js
@@ -9,9 +9,7 @@ module.exports = {
   postcssConfig: {
     plugins: [
       rucksack(),
-      autoprefixer({
-        browsers: ['last 2 versions', 'Firefox ESR', '> 1%', 'ie >= 8', 'iOS >= 8', 'Android >= 4'],
-      }),
+      autoprefixer(),
       svgo(),
     ]
   }


### PR DESCRIPTION
```
  Replace Autoprefixer browsers option to Browserslist config.
  Use browserslist key in package.json or .browserslistrc file.

  Using browsers option cause some error. Browserslist config 
  can be used for Babel, Autoprefixer, postcss-normalize and other tools.

  If you really need to use option, rename it to overrideBrowserslist.

  Learn more at:
  https://github.com/browserslist/browserslist#readme
  https://twitter.com/browserslist
```

https://github.com/ant-design/ant-design/issues/16970

https://circleci.com/docs/2.0/skip-build/