### PR TITLE
feat: support postManifest & postBuild

### DIFF
--- a/packages/bisheng-plugin-react/package.json
+++ b/packages/bisheng-plugin-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bisheng-plugin-react",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "description": "To convert JSX which is written in Markdown to React.Element.",
   "repository": {
     "type": "git",

--- a/packages/bisheng/src/index.js
+++ b/packages/bisheng/src/index.js
@@ -231,7 +231,10 @@ exports.build = function build(program, callback) {
       console.log(stats.toString('errors-only'));
       return;
     }
-    const manifest = getManifest(stats.compilation)[bishengConfig.entryName];
+    let manifest = getManifest(stats.compilation)[bishengConfig.entryName];
+    if (bishengConfig.postManifest) {
+      manifest = bishengConfig.postManifest(manifest);
+    }
 
     const markdown = sourceData.generate(bishengConfig.source, bishengConfig.transformers);
     let filesNeedCreated = generateFilesPath(themeConfig.routes, markdown).map(
@@ -300,7 +303,12 @@ exports.build = function build(program, callback) {
           });
         });
       });
+
       Promise.all(fileCreatedPromises).then(() => {
+        if (bishengConfig.postBuild) {
+          bishengConfig.postBuild();
+        }
+
         if (callback) {
           callback();
         }


### PR DESCRIPTION
用于 cssinjs 的样式提取。

Note: `bisheng` 不支持 wrapper，只能做注入实现。代码很黑，不过重构成本更大，只能先这样子了。

